### PR TITLE
Add no-output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ const container = `<div class="${styles.container}">...</div>`;
 
 * `include`, `exclude`: A minimatch pattern, or an array of minimatch patterns of including ID, or excluding ID (optional).
 * `output`: Output destination (optional).
-  * If you specify a `string`, it will be the path to write the generated CSS.
-  * If you specify a `function`, call it passing the generated CSS as an argument.
+  * If you specify as `string`, it will be the path to write the generated CSS.
+  * If you specify as `function`, call it passing the generated CSS as an argument.
+  * If you specify the `false`, CSS will not be output.
   * If this option is not specified, the generated CSS will still be imported (See [Use with other CSS plugins](#use-with-other-css-plugins)).
 * `sourceMap`: If `true` is specified, source map to be embedded in the output CSS (default is `true`).
 * `fn`: A function invoked with the Stylus renderer (it will be passed to `use()` function of the Stylus).

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export default function stylusCssModules(options = {}) {
   const sourceMap = options.sourceMap !== false;
   const outputFile = typeof options.output === 'string';
   const outputFunction = typeof options.output === 'function';
+  const noOutput = options.output === false;
   const cache = {};
 
   return {
@@ -63,7 +64,7 @@ export default function stylusCssModules(options = {}) {
         await fs.writeFile(options.output, obj.injectableSource);
       } else if (outputFunction) {
         await options.output(obj.injectableSource);
-      } else {
+      } else if (!noOutput) {
         importCode = `import ${JSON.stringify(compiledId)};`;
       }
 

--- a/test/stylus-css-modules-test.js
+++ b/test/stylus-css-modules-test.js
@@ -47,6 +47,22 @@ describe('stylus-css-modules', () => {
     });
   });
 
+  it('should not output CSS', () => {
+    return rollup({
+      entry: 'test/example/main.js',
+      plugins: [
+        stylusCssModules({
+          output: false
+        })
+      ]
+    }).then((bundle) => {
+      const result = bundle.generate({format: 'cjs'});
+      const exports = {};
+      const module = {exports};
+      runInNewContext(result.code, {module, exports});
+    });
+  });
+
   it('should be work the next css plugin', () => {
     const filter = createFilter('**/*.css');
     let output = null;


### PR DESCRIPTION
Add `output: false` option for not output CSS.

Example:

```js
import stylusCssModules from 'rollup-plugin-stylus-css-modules';

export default {
  entry: 'path/to.js',
  plugins: [
    stylusCssModules({output: false})
  ]
};
```